### PR TITLE
Appropriately declare fabric registry sync dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,7 +127,7 @@ publishMods {
 
         projectDescription = rootProject.file("README.md").readText()
 
-        requires("polymer", "placeholder-api")
+        requires("polymer", "placeholder-api", "fabric-api")
     }
 }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,8 @@
     "depends": {
         "minecraft": ">=1.21",
         "polymer-core": ">=0.9.0",
-        "placeholder-api": ">=2.4.0"
+        "placeholder-api": ">=2.4.0",
+        "fabric-registry-sync-v0": "*"
     },
     "mixins": ["${id}.mixins.json"]
 }


### PR DESCRIPTION
The mod requires Fabric Registry Sync to load due to registry freezing, this declares the dependency on the specific module it needs, and adds Fabric API as a required dep to the Modrinth publishing as well.

I would recommend also going back and updating past versions on Modrinth to add this dependency. 

Closes #1